### PR TITLE
feat: withConn does not add select statement

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -280,34 +280,10 @@ func (c *baseClient) withConn(
 	if err != nil {
 		return err
 	}
-
 	defer func() {
 		c.releaseConn(ctx, cn, err)
 	}()
-
-	done := ctx.Done() //nolint:ifshort
-
-	if done == nil {
-		err = fn(ctx, cn)
-		return err
-	}
-
-	errc := make(chan error, 1)
-	go func() { errc <- fn(ctx, cn) }()
-
-	select {
-	case <-done:
-		_ = cn.Close()
-		// Wait for the goroutine to finish and send something.
-		<-errc
-
-		err = ctx.Err()
-	case err = <-errc:
-	}
-	if err != nil {
-		return fmt.Errorf("execute with conn: %w", err)
-	}
-	return nil
+	return fn(ctx, cn)
 }
 
 func (c *baseClient) process(ctx context.Context, cmd Cmder) error {


### PR DESCRIPTION
The function passed to withConn is already context aware. By using a separate select we only add another level of indirection which makes it hard to analyze the program and provides less-than-useful error messages in case the context is cancelled. Additionally, we now have a race condition between the two select cases when the context is cancelled leading to possibly inconsistent error messages. In reality the case for the local context seems to win out almost all the time which only exacerbates the problem of meaningless error messages.